### PR TITLE
[fix] 변환이미지 RGB 재배열, 선택 dnn 모델 추가 #2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,5 +142,5 @@ media/
 
 *.json
 
-musiclist/settings.py
+*.t7
 

--- a/nst.py
+++ b/nst.py
@@ -18,7 +18,9 @@ def styletransfer(idx, num):
         4:"starry_night.t7",
         5:"la_muse.t7",
         6:"the_scream.t7",
-        7:"udnie.t7"
+        7:"udnie.t7",
+        8:"composition_vii.t7",
+        9:"the_wave.t7"
         }
     
     dnn_model = dnn_models[int(num)]
@@ -44,11 +46,11 @@ def styletransfer(idx, num):
     output = np.clip(output, 0, 255)
     output = output.astype('uint8')
 
+    # 색 재배열
+    output = cv2.cvtColor(output, cv2.COLOR_BGR2RGB)
     # 이미지 저장하기 위해 np array를 이미지로 바꿔줌
     result_img = im.fromarray(output)
     
-
-    # RGB 배치 필요
     # 이미지저장, db에도 저장
     result_img.save(f'media/results/{idx}.jpg', "JPEG")
     target.output_image = f'results/{idx}.jpg'


### PR DESCRIPTION
1. 저장되는 이미지 색이 반대로 나와서 RGB 재배열했습니다.
2. 선택 dnn모델 추가했습니다.